### PR TITLE
Remove SCOS affinity and tolerations from public chart: in deploy repo

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   - name: strimzi-kafka-operator

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -31,19 +31,3 @@ tlsSidecar:
     limits:
       cpu: 100m
       memory: 128Mi
-
-tolerations:
-  - key: scos.run.kafka
-    operator: Equal
-    value: "true"
-    effect: NoExecute
-
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: scos.run.kafka
-              operator: In
-              values:
-                - "true"

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -31,3 +31,7 @@ tlsSidecar:
     limits:
       cpu: 100m
       memory: 128Mi
+
+tolerations: []
+
+affinity: {}

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 3.1.1
 - name: kafka
   repository: file://../kafka
-  version: 1.0.1
+  version: 1.0.2
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
   version: 1.6.0
@@ -44,5 +44,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.0
-digest: sha256:9c27233682a63b4a9543deba01bdd99bd27cd4cc24bb3c966dd6a444861dfa33
-generated: "2021-09-20T13:52:12.770852-05:00"
+digest: sha256:12ba3aa10a8a280c1dadb2ffb2c6e88ab296fa0f4462918a7e54a52e57046abe
+generated: "2021-09-30T12:21:04.144684-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the data platform.
 name: urban-os
-version: 1.8.0
+version: 1.8.1
 
 dependencies:
   - name: andi
     version: 2.1.3
     repository: file://../andi
-    condition: andi.enabled 
+    condition: andi.enabled
   - name: discovery-api
     version: 1.2.0
     repository: file://../discovery-api
@@ -24,7 +24,7 @@ dependencies:
   - name: elasticsearch
     version: 7.14.0
     repository: https://helm.elastic.co
-    condition: elasticsearch.enabled  
+    condition: elasticsearch.enabled
   - name: external-services
     version: 1.0.0
     repository: file://../external-services
@@ -32,15 +32,15 @@ dependencies:
   - name: forklift
     version: 3.1.1
     repository: file://../forklift
-    condition: forklift.enabled  
+    condition: forklift.enabled
   - name: kafka
-    version: 1.0.1
+    version: 1.0.2
     repository: file://../kafka
     condition: kafka.enabled
   - name: kubernetes-data-platform
     version: 1.6.0
     repository: file://../kubernetes-data-platform
-    condition: kubernetes-data-platform.enabled  
+    condition: kubernetes-data-platform.enabled
   - name: monitoring
     version: 1.0.1
     repository: file://../monitoring


### PR DESCRIPTION
These map kafka containers to specific EC2s that we configured for SCOS. These mappings should be in the deploy repo, instead of the public chart.

We noticed because, when deploying elsewhere (where we don't have these specific EC2s) we were unable to override these config values. (Due to a helm bug: https://github.com/helm/helm/issues/9136)

Regardless, they should be moved from the public chart to the deploy repo since they're deployment specific.

